### PR TITLE
fix crash problem in QCoreApplication::arguments

### DIFF
--- a/src/top.cc
+++ b/src/top.cc
@@ -17,7 +17,7 @@ Handle<Value> ProcessEvents(const Arguments& args) {
 void Initialize(Handle<Object> target) {
   Browser::Initialize(target);
   
-  int argc = 0;
+  static int argc = 0;
   char** argv = NULL;
   app = new QApplication(argc, argv);
   


### PR DESCRIPTION
The constructor of QApplication takes a reference to int,
so argc must not be a local variable.

Fixes #28.
