### PR TITLE
docs: fix simple typo, passsing -> passing

### DIFF
--- a/openssl/crypto/x509/x509.h
+++ b/openssl/crypto/x509/x509.h
@@ -1009,7 +1009,7 @@ int 		X509_NAME_get_text_by_NID(X509_NAME *name, int nid,
 int		X509_NAME_get_text_by_OBJ(X509_NAME *name, ASN1_OBJECT *obj,
 			char *buf,int len);
 
-/* NOTE: you should be passsing -1, not 0 as lastpos.  The functions that use
+/* NOTE: you should be passing -1, not 0 as lastpos.  The functions that use
  * lastpos, search after that position on. */
 int 		X509_NAME_get_index_by_NID(X509_NAME *name,int nid,int lastpos);
 int 		X509_NAME_get_index_by_OBJ(X509_NAME *name,ASN1_OBJECT *obj,

--- a/openssl/crypto/x509/x509name.c
+++ b/openssl/crypto/x509/x509name.c
@@ -104,7 +104,7 @@ int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
 	return(X509_NAME_get_index_by_OBJ(name,obj,lastpos));
 	}
 
-/* NOTE: you should be passsing -1, not 0 as lastpos */
+/* NOTE: you should be passing -1, not 0 as lastpos */
 int X509_NAME_get_index_by_OBJ(X509_NAME *name, ASN1_OBJECT *obj,
 	     int lastpos)
 	{


### PR DESCRIPTION
There is a small typo in openssl/crypto/x509/x509.h, openssl/crypto/x509/x509name.c.

Should read `passing` rather than `passsing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md